### PR TITLE
Add SSL Support and fix zero-out logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ All code is licensed under the [Apache License](http://www.apache.org/licenses/L
 ###v0.2.2
 
 * Changed over all URL references to WaniKani to SSL
+* Rewrote review page to update when viewing reviews summary
 
 ###v0.2.1
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ All code is licensed under the [Apache License](http://www.apache.org/licenses/L
 
 ## Changelog
 
+###v0.2.2
+
+* Changed over all URL references to WaniKani to SSL
+
 ###v0.2.1
 
 * Updated review page monitor for new review page style

--- a/background.js
+++ b/background.js
@@ -44,7 +44,7 @@ function fetch_reviews() {
                     });
                 }
             };
-            var url = "http://www.wanikani.com/api/v1.1/user/" + encodeURIComponent(api_key) + "/study-queue";
+            var url = "https://www.wanikani.com/api/v1.1/user/" + encodeURIComponent(api_key) + "/study-queue";
             xhr.open("GET", url);
             xhr.send();
         }

--- a/background.js
+++ b/background.js
@@ -151,7 +151,7 @@ chrome.browserAction.onClicked.addListener(function() {
         if (result === "!") {
             chrome.tabs.create({url: "options.html"});
         } else {
-            chrome.tabs.create({url: "http://www.wanikani.com"});
+            chrome.tabs.create({url: "https://www.wanikani.com"});
         }
     });
 });

--- a/manifest.json
+++ b/manifest.json
@@ -9,7 +9,12 @@
   "options_page": "options.html",
   "content_scripts": [
     {
-      "matches": ["https://www.wanikani.com/review", "http://www.wanikani.com/review"],
+      "run_at": "document_idle",
+      "matches": [
+        "https://www.wanikani.com/review",
+        "https://www.wanikani.com/review/", 
+        "http://www.wanikani.com/review",
+        "http://www.wanikani.com/review/"],
       "js": ["review_page.js"]
     }
   ],

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "__MSG_wanikaninotify_name__",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "manifest_version": 2,
   "description": "__MSG_wanikaninotify_description__",
   "default_locale": "en",

--- a/manifest.json
+++ b/manifest.json
@@ -9,11 +9,11 @@
   "options_page": "options.html",
   "content_scripts": [
     {
-      "matches": ["http://www.wanikani.com/review"],
+      "matches": ["https://www.wanikani.com/review", "http://www.wanikani.com/review"],
       "js": ["review_page.js"]
     }
   ],
-  "permissions": ["alarms", "storage", "notifications", "http://www.wanikani.com/api/*"],
+  "permissions": ["alarms", "storage", "notifications", "https://www.wanikani.com/api/*"],
   "browser_action": {
     "default_title": "WaniKani Notifier",
     "default_icon": "icon_128.png"

--- a/options.html
+++ b/options.html
@@ -9,7 +9,7 @@
 <body>
 
 <h3>WaniKani Notifier</h3>
-To find your API key, go to <a href="http://www.wanikani.com" target="_blank">WaniKani</a>, click Menu, then click Settings (under Account). Copy the field labeled "Public API Key" into the box below.
+To find your API key, go to <a href="https://www.wanikani.com" target="_blank">WaniKani</a>, click Menu, then click Settings (under Account). Copy the field labeled "Public API Key" into the box below.
 <br><br>
 <label for="api_key">Enter your API key here:</label>
 <input id="api_key" size="32" />

--- a/options.js
+++ b/options.js
@@ -51,7 +51,7 @@ function save_options() {
                 });
             }
         };
-        var url = "http://www.wanikani.com/api/v1.1/user/" + encodeURIComponent(api_key) + "/study-queue";
+        var url = "https://www.wanikani.com/api/v1.2/user/" + encodeURIComponent(api_key) + "/study-queue";
         xhr.open("GET", url);
         xhr.send();
 

--- a/review_page.js
+++ b/review_page.js
@@ -3,23 +3,12 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 
-
-var is_complete = document.getElementById("notice");
-
-if (is_complete) {
-    chrome.extension.sendMessage({reviews_available: 0});
-} else {
-
-    var observer = new WebKitMutationObserver(function (mutations) {
-        var is_complete = document.getElementById("notice");
-        if (is_complete) {
-            // If "Review Completed" appears, set reviews to 0
-            chrome.extension.sendMessage({reviews_available: 0});
-            // Prevent the observer from firing multiple times
-            observer.disconnect();
-        }
-    });
-    // Monitor to see if children of #reviews are added or removed.
-    // Only fires when "Review Completed" appears.
-    observer.observe(document, { childList: true, subtree: false, attributes:false, characterData: false });
+function checkForReviewCount(evt){
+    if (document.getElementById("review-queue-count") !== undefined && 
+        document.getElementById("review-queue-count").textContent == "0") {
+        chrome.extension.sendMessage({reviews_available: 0});
+    } 
 }
+
+// force an event listener for pageload since the count is delayed
+window.addEventListener ("load", checkForReviewCount, false);

--- a/review_page.js
+++ b/review_page.js
@@ -3,12 +3,23 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 
-function checkForReviewCount(evt){
-    if (document.getElementById("review-queue-count") !== undefined && 
-        document.getElementById("review-queue-count").textContent == "0") {
-        chrome.extension.sendMessage({reviews_available: 0});
-    } 
+function isComplete(){
+	(document.getElementById("review-queue-count") !== undefined && 
+        document.getElementById("review-queue-count").textContent == "0");
 }
 
-// force an event listener for pageload since the count is delayed
-window.addEventListener ("load", checkForReviewCount, false);
+if (isComplete()) {
+    chrome.extension.sendMessage({reviews_available: 0});
+} else {
+    var observer = new WebKitMutationObserver(function (mutations) {
+        if (isComplete()) {
+            // If "Review Completed" appears, set reviews to 0
+            chrome.extension.sendMessage({reviews_available: 0});
+            // Prevent the observer from firing multiple times
+            observer.disconnect();
+        }
+    });
+    // Monitor to see if children of #reviews are added or removed.
+    // Only fires when "Review Completed" appears.
+    observer.observe(document, { childList: true, subtree: false, attributes:false, characterData: false });
+}


### PR DESCRIPTION
- I went through and changed all of the references to WaniKani to use SSL (to not leak the api token over http).
- The review summary count-reseter appears to not work either, so I swapped the old logic for a simple pageload lookup at the review summary page after a review.
